### PR TITLE
(fix) Don't show old forecast data for previously selected location, …

### DIFF
--- a/src/app/components/ForecastTable/ForecastTable.tsx
+++ b/src/app/components/ForecastTable/ForecastTable.tsx
@@ -22,6 +22,8 @@ export default function ForecastTable() {
   const { table } = classes;
   const forecast = useSelector((state: RootStateInterface) => state.weather);
 
+  if (forecast[0].index === 0) return <></>;
+
   const forecastTableHead = (
     <TableHead>
       <TableRow>

--- a/src/app/components/ZipCode/ZipCode.tsx
+++ b/src/app/components/ZipCode/ZipCode.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { removeZipCode } from '../../../store/actions/zipCodes';
-import { updateForecast } from '../../../store/actions/weather';
+import { updateForecast, resetForecast } from '../../../store/actions/weather';
 import {
   fetchCurrentConditions,
   fetchForecast,
@@ -26,6 +26,7 @@ const ZipCode: React.FC<ZipCodesInterface> = props => {
   const [longitude, setLongitude] = useState(0);
 
   async function getUpdatedForecast() {
+    dispatch(resetForecast());
     const result = await fetchForecast(latitude, longitude);
     dispatch(updateForecast(result));
   }

--- a/src/store/actionTypes.ts
+++ b/src/store/actionTypes.ts
@@ -8,4 +8,5 @@ export enum ZipCodeActionTypes {
 }
 export enum WeatherActionTypes {
   UPDATE_FORECAST = 'UPDATE_FORECAST',
+  INITIAL_STATE = 'INITIAL_STATE',
 }

--- a/src/store/actions/weather.ts
+++ b/src/store/actions/weather.ts
@@ -4,3 +4,8 @@ export function updateForecast(payload: object | undefined) {
     payload,
   };
 }
+export function resetForecast() {
+  return {
+    type: 'INITIAL_STATE',
+  };
+}

--- a/src/store/reducers/weatherReducer.ts
+++ b/src/store/reducers/weatherReducer.ts
@@ -18,13 +18,15 @@ const initialState: WeatherInterface = {
 };
 
 export default function weather(
-  state: WeatherInterface = initialState,
+  state: WeatherInterface[] = [initialState],
   action: { type: WeatherActionTypes; payload: WeatherInterface },
 ) {
   const { payload, type } = action;
   switch (type) {
     case 'UPDATE_FORECAST':
       return payload;
+    case 'INITIAL_STATE':
+      return [initialState];
     default:
       return state;
   }


### PR DESCRIPTION
…only shows Forecast Table when data for recently clicked location is available